### PR TITLE
fix synchronizing from new to old

### DIFF
--- a/src/Console/Commands/SynchronizeCommand.php
+++ b/src/Console/Commands/SynchronizeCommand.php
@@ -50,6 +50,7 @@ class SynchronizeCommand extends Command
     public function handle()
     {
         $files = $this->synchronizer->getSynchronizations();
+
         $fileNames = $files->map(function ($file) {
             return $file->getFileName();
         });
@@ -79,5 +80,4 @@ class SynchronizeCommand extends Command
 
         $this->info('Synchronizations completed');
     }
-
 }


### PR DESCRIPTION
Previously synchronizations were not explicitly sorted so a file named 'a' was synchornized before 'b' even if 'b' was created before 'a'.

This will fix this so it will synchronize like expected.

Deprecates one method because not being used anymore.

Fixes #2