### PR TITLE
Handle synchronizations based on migration events

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ php artisan migrate
 
 ## Usage
 
+Laravel Synchronize executes synchronizations that have the same class name as the migration class name, but with a Synchronization suffix, when executing migrations. This is the advised usage to ensure database integrity, but it is possible to execute synchronizations on their own (see section Synchronize command).
+
 #### Make command
 
 ```shell
@@ -82,14 +84,14 @@ Creates the synchronization file at `database/synchronizations`
 #### Synchronize command
 
 ```shell
-php artisan laravel-sync:synchronize
+php artisan synchronize
 ```
 
 #### Using --class and --force
 
 It can happen you need a synchronization before you can perform a migration. Using --class and --force can help you achieving that goal.
 
-All you need to do is using the Laravel 5.8.16+ Migration events, or simply call them in the up or down method when lower.
+All you need to do is using the Laravel 5.8.16+ Migration events.
 
 Example:
 
@@ -98,7 +100,7 @@ Example:
     {
         Event::listen(MigrationStarted::class, function (MigrationStarted $listener) {
             if ($listener->migration instanceof $this && $listener->method === 'up') {
-                Artisan::call('laravel-sync:synchronize --class=TestASync --force');
+                Artisan::call('synchronize --class=TestASync --force');
                 echo Artisan::output();
             }
         });

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,10 @@
     "name": "netcreaties/laravel-synchronize",
     "description": "Laravel Synchronizations will enable you to create one time synchronizations and prevent creating commands you only use once",
     "type": "library",
-    "keywords": ["laravel","lumen"],
+    "keywords": [
+        "laravel",
+        "lumen"
+    ],
     "require": {},
     "require-dev": {
         "matthewbdaly/artisan-standalone": "0.0.*",
@@ -21,6 +24,10 @@
         {
             "name": "Roy Freij",
             "email": "info@royfreij.nl"
+        },
+        {
+            "name": "Ramon Bakker",
+            "email": "ramon@bsbip.com"
         }
     ],
     "autoload": {

--- a/src/Console/Commands/MakeSynchronizationCommand.php
+++ b/src/Console/Commands/MakeSynchronizationCommand.php
@@ -2,8 +2,8 @@
 
 namespace LaravelSynchronize\Console\Commands;
 
-use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
 use LaravelSynchronize\Console\Synchronizer\Synchronizer;
 
 class MakeSynchronizationCommand extends GeneratorCommand
@@ -57,7 +57,7 @@ class MakeSynchronizationCommand extends GeneratorCommand
      */
     public function handle()
     {
-        $name = $this->qualifyClass(Str::studly($this->getNameInput()));
+        $name = $this->qualifyClass(Str::studly($this->getNameInput() . 'Synchronization'));
         $path = $this->getPath($this->getNameInput());
 
         if ($this->alreadyExists($this->getNameInput())) {

--- a/src/Console/Commands/stubs/Synchronization.stub
+++ b/src/Console/Commands/stubs/Synchronization.stub
@@ -10,11 +10,21 @@ class DummyClass
     public $withTransactions = true;
 
     /**
-     * Handle the synchronization.
+     * Run the synchronization.
      *
      * @return void
      */
-    public function handle()
+    public function up()
+    {
+        //
+    }
+
+    /**
+     * Rollback the synchronization.
+     *
+     * @return void
+     */
+    public function down()
     {
         //
     }

--- a/src/Listeners/MigrationEndedEventListener.php
+++ b/src/Listeners/MigrationEndedEventListener.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace LaravelSynchronize\Listeners;
+
+use Illuminate\Database\Events\MigrationEnded;
+use LaravelSynchronize\Console\Synchronizer\Synchronizer;
+use LaravelSynchronize\Console\Synchronizer\SynchronizerRepository;
+
+class MigrationEndedEventListener
+{
+    /**
+     * The Synchronizer instance.
+     *
+     * @var \LaravelSynchronize\Console\Synchronizer\Synchronizer
+     */
+    protected $synchronizer;
+
+    /**
+     * @var \LaravelSynchronize\Console\Synchronizer\SynchronizerRepository $synchronizerRepository
+     */
+    protected $synchronizerRepository;
+
+    public function __construct(Synchronizer $synchronizer, SynchronizerRepository $synchronizerRepository)
+    {
+        $this->synchronizer = $synchronizer;
+        $this->synchronizerRepository = $synchronizerRepository;
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @todo use MigrationsStarted event to collect synchronizations
+     *
+     * @param MigrationEnded $migrationEnded
+     *
+     * @return void
+     *
+     * @author Ramon Bakker <ramon@bsbip.com>
+     * @version 1.0.0
+     */
+    public function handle(MigrationEnded $migrationEnded)
+    {
+        // Synchronizations should execute after going down
+        if ($migrationEnded->method !== 'down') {
+            return;
+        }
+
+        $class = get_class($migrationEnded->migration) . 'Synchronization';
+        $files = $this->synchronizer->getSynchronizations();
+
+        $handledFiles = collect($this->synchronizerRepository->getLast())
+            ->pluck('synchronization');
+
+        $filesToHandle = $files->filter(function ($file) use ($handledFiles) {
+            return $handledFiles->contains($file->getFileName());
+        });
+
+        if ($filesToHandle->isEmpty()) {
+            echo "No synchronization found for {$class}\n";
+
+            return;
+        }
+
+        $filesToHandle->each(function ($file) {
+            echo 'Rolling back synchronization: ' . $file->getFileName() . "\n";
+
+            $this->synchronizer->run($file, 'down');
+
+            echo 'Rolled back synchronization: ' . $file->getFileName() . "\n";
+        });
+    }
+}

--- a/src/Listeners/MigrationStartedEventListener.php
+++ b/src/Listeners/MigrationStartedEventListener.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace LaravelSynchronize\Listeners;
+
+use SplFileInfo;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Database\Events\MigrationStarted;
+use LaravelSynchronize\Console\Synchronizer\Synchronizer;
+
+class MigrationStartedEventListener
+{
+    /**
+     * The Synchronizer instance.
+     *
+     * @var \LaravelSynchronize\Console\Synchronizer\Synchronizer
+     */
+    protected $synchronizer;
+
+    public function __construct(Synchronizer $synchronizer)
+    {
+        $this->synchronizer = $synchronizer;
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @todo use MigrationsStarted event to collect synchronization files
+     *
+     * @param MigrationStarted $migrationStarted
+     *
+     * @return void
+     *
+     * @author Ramon Bakker <ramon@bsbip.com>
+     * @version 1.0.0
+     */
+    public function handle(MigrationStarted $migrationStarted)
+    {
+        // Synchronizations should execute before going up
+        if ($migrationStarted->method !== 'up') {
+            return;
+        }
+
+        $class = get_class($migrationStarted->migration) . 'Synchronization';
+        $files = $this->synchronizer->getSynchronizations();
+
+        $fileNames = $files->map(function ($file) {
+            return $file->getFileName();
+        });
+
+        $handledFiles = DB::table(Config::get('synchronizer.table'))->pluck('synchronization');
+        $unHandledFiles = $fileNames->diff($handledFiles);
+
+        $filesToHandle = $files->filter(function ($file) use ($unHandledFiles, $class) {
+            return $unHandledFiles->contains($file->getFileName())
+                && (!$class || ($class === $this->getClassName($file)));
+        });
+
+        if ($filesToHandle->isEmpty()) {
+            echo "No synchronization found for {$class}\n";
+
+            return;
+        }
+
+        $filesToHandle->each(function ($file) {
+            echo 'Synchronizing: ' . $file->getFileName() . "\n";
+
+            $this->synchronizer->run($file, 'up');
+
+            echo 'Synchronized: ' . $file->getFileName() . "\n";
+        });
+    }
+
+    /**
+     * Get class name for file
+     *
+     * @param SplFileInfo $file
+     *
+     * @return string
+     */
+    private function getClassName(SplFileInfo $file): string
+    {
+        return $this->synchronizer->getClassName(
+            $this->synchronizer->getSynchronizationName($file->getFilename())
+        );
+    }
+}

--- a/src/Providers/LaravelSynchronizeEventServiceProvider.php
+++ b/src/Providers/LaravelSynchronizeEventServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LaravelSynchronize\Providers;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+
+/**
+ * Event service provider
+ */
+class LaravelSynchronizeEventServiceProvider extends EventServiceProvider
+{
+    /**
+     * The event handler mappings for the application.
+     *
+     * @var array
+     */
+    protected $listen = [
+        'Illuminate\Database\Events\MigrationStarted' => [
+            'LaravelSynchronize\Listeners\MigrationStartedEventListener',
+        ],
+        'Illuminate\Database\Events\MigrationEnded' => [
+            'LaravelSynchronize\Listeners\MigrationEndedEventListener',
+        ],
+    ];
+}

--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace LaravelSynchronize\Providers;
 
+use LaravelSynchronize\Console\Commands\SynchronizeCommand;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use LaravelSynchronize\Console\Commands\MakeSynchronizationCommand;
-use LaravelSynchronize\Console\Commands\SynchronizeCommand;
 
 /**
  * Service provider
@@ -34,6 +34,8 @@ class ServiceProvider extends BaseServiceProvider
             $this->getDefaultConfigFilePath('synchronizer'),
             'synchronizer'
         );
+
+        $this->app->register(LaravelSynchronizeEventServiceProvider::class);
     }
 
     /**


### PR DESCRIPTION
This adds listeners for the MigrationStarted and MigrationEnded events.
These listeners will handle synchronizations for each migration. This
makes use of the synchronize command unnecessary.

Synchronizations should have an up and down function like migrations do. That makes going back a build easier, but it can also help with testing.